### PR TITLE
gz-sim-cli: install executable in libexec

### DIFF
--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim9 (9.2.0-2~jammy) jammy; urgency=medium
+
+  * gz-sim9 9.2.0-2 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Thu, 26 Jun 2025 19:24:00 +0000
+
 gz-sim9 (9.2.0-1~jammy) jammy; urgency=medium
 
   * gz-sim9 9.2.0-1 release

--- a/noble/debian/changelog
+++ b/noble/debian/changelog
@@ -1,3 +1,9 @@
+gz-sim9 (9.2.0-2~noble) noble; urgency=medium
+
+  * gz-sim9 9.2.0-2 release
+
+ -- Steve Peters <scpeters@openrobotics.org>  Thu, 26 Jun 2025 19:24:00 +0000
+
 gz-sim9 (9.2.0-1~noble) noble; urgency=medium
 
   * gz-sim9 9.2.0-1 release

--- a/ubuntu/debian/gz-sim-cli.install
+++ b/ubuntu/debian/gz-sim-cli.install
@@ -1,3 +1,4 @@
+usr/libexec/gz/sim*/*
 usr/lib/ruby/gz/*.rb
 usr/share/*/*[0-99].yaml
 usr/share/*/model[0-99].yaml


### PR DESCRIPTION
Similar to https://github.com/gazebo-release/gz-sim10-release/pull/6.

Fixes unstable noble debbuild from 9.2.0:

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=gz-sim9-debbuilder&build=767)](https://build.osrfoundation.org/job/gz-sim9-debbuilder/767/) https://build.osrfoundation.org/job/gz-sim9-debbuilder/767/

~~~
dh_missing: warning: usr/libexec/gz/sim9/gz-sim-model exists in debian/tmp but is not installed to anywhere 
~~~